### PR TITLE
Loại trừ thư mục môi trường ảo Python ra khỏi Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
+# Python virtual environment
+.venv/
+venv/
+
+# Python cache
 __pycache__/
+
+# SQLite
 db.sqlite3


### PR DESCRIPTION
### THAY ĐỔI:
- Loại trừ thư mục môi trường ảo Python ra khỏi Git